### PR TITLE
Fix pip install command for manual installs

### DIFF
--- a/docs/installation/manual.md
+++ b/docs/installation/manual.md
@@ -88,13 +88,13 @@ The following commands vary depending on the version of Invoke being installed a
 8. Install the `invokeai` package. Substitute the package specifier and version.
 
     ```sh
-    uv pip install <PACKAGE_SPECIFIER>=<VERSION> --python 3.11 --python-preference only-managed --force-reinstall
+    uv pip install <PACKAGE_SPECIFIER>==<VERSION> --python 3.11 --python-preference only-managed --force-reinstall
     ```
 
     If you determined you needed to use a `PyPI` index URL in the previous step, you'll need to add `--index=<INDEX_URL>` like this:
 
     ```sh
-    uv pip install <PACKAGE_SPECIFIER>=<VERSION> --python 3.11 --python-preference only-managed --index=<INDEX_URL> --force-reinstall
+    uv pip install <PACKAGE_SPECIFIER>==<VERSION> --python 3.11 --python-preference only-managed --index=<INDEX_URL> --force-reinstall
     ```
 
 9. Deactivate and reactivate your venv so that the invokeai-specific commands become available in the environment:


### PR DESCRIPTION
## Summary

These's an error in the doc for manual installations it seems. It tells the reader to execute

```
uv pip install invokeai=5.5.0 --python 3.11 --python-preference only-managed --force-reinstall
```

produces here (MacOS):

```
error: Failed to parse: `invokeai=5.5.0`
  Caused by: no such comparison operator "=", must be one of ~= == != <= >= < > ===
invokeai=5.5.0
        ^^^^^^
```

With the `==`-operator, this works.

## QA Instructions

Please try the old command in a non-MacOS environment, as well as the new one, to be sure that we're not just having platform incompatibilities.

## Checklist

- [x] _The PR has a short but descriptive title, suitable for a changelog_
- [x] _Documentation added / updated (if applicable)_
